### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,11 @@
 # .github/workflows/deploy.yml
 name: Deploy Nexus Ecosystem
 
+permissions:
+  contents: read
+  packages: write
+  actions: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/peteywee/nexus_mind/security/code-scanning/2](https://github.com/peteywee/nexus_mind/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, the following permissions are needed:
- `contents: read` for accessing the repository's code.
- `packages: write` for pushing Docker images to GitHub Container Registry (GHCR).
- `actions: read` for using reusable workflows or actions.

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
